### PR TITLE
Fix setup.py by removing 'uuid' from install_requires list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ setup(
     packages=find_packages(include=['core', 'core.*']),
     install_requires=[
         'numpy',
-        'uuid',
         'pydantic',
         'psutil',
         'scikit-learn',


### PR DESCRIPTION
Including uuid as an installation requirement causes an error when users try to install the package from PyPI because pip cannot find a version of 'uuid' to install - 'uuid' package is part of Python's Standard Library and is always available in any Python environment.

This change should resolve the installation error and enable users to install the package without any issues."