### PR TITLE
build(requirements): add missing requirements psutil and sklearn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,5 @@ PyJWT==2.7.0
 python-dotenv==1.0.0
 typing_extensions==4.7.1
 Werkzeug==2.3.6
-tinyvector==0.1.0
+psutil==6.0.0
+scikit-learn=1.5.2


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ef488432-c904-4f6d-9981-4db33a8b6c13)
![image](https://github.com/user-attachments/assets/0ef995dd-5813-4637-94d1-827d0c673785)


The above images are what I got while I was trying to run your project on Ubuntu 22.04 with v3.10.12 python.

After this patch, the server runs normal.

![image](https://github.com/user-attachments/assets/e01c3ad0-6bb6-4818-b1e5-56ff4898e9dd)
